### PR TITLE
fix: use % instead of vw for footer width

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -30,7 +30,7 @@ const PCLayout = () => {
 const Footer = () => {
   return (
     <Box
-      w="100vw"
+      w="100%"
       h="11vh"
       position="absolute"
       alignItems="center"


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- link to a relevant issue. -->

Footer の横幅に `100vw` が指定されていたことによりスクロールバーの分がはみ出ていたので、`100%` に修正しました。

ふと気になったので直してしまいましたが、PR を受け付けていない場合はそっと閉じていただいて構いません。

Issue Number: N/A

<!--- Describe your changes in detail. -->
